### PR TITLE
Reusing default options from DefaultRecipe

### DIFF
--- a/Type2AGN.jl
+++ b/Type2AGN.jl
@@ -7,24 +7,14 @@ import QSFit: default_options, known_spectral_lines, add_qso_continuum!, add_pat
 abstract type Type2AGN <: DefaultRecipe end
 
 function QSFit.default_options(::Type{T}) where T <: Type2AGN
-    out = OrderedDict{Symbol, Any}()
-    out[:wavelength_range] = [1215, 7.3e3]
-    out[:min_spectral_coverage] = Dict(:default => 0.6,
-                                       :ironuv  => 0.3,
-                                       :ironopt => 0.3)
-    out[:skip_lines] = Symbol[]
-    out[:host_template] = Dict(:library=>"swire", :template=>"Ell5")
-    out[:use_host_template] = true
+    out = default_options(supertype(T))
     out[:use_balmer] = false
     out[:use_ironuv] = false
     out[:use_ironopt] = false
-    out[:use_lorentzian_profiles] = false
     out[:n_unk] = 2
     out[:unk_avoid] = [4863 .+ [-1,1] .* 50, 
                        6565 .+ [-1,1] .* 150,
                        5008 .+ [-1,1] .* 25]
-    out[:line_broadening] = true
-    out[:norm_integrated] = true
     out[:line_profiles] = :gauss
     return out
 end


### PR DESCRIPTION
This PR allows to reuse default options from DefaultRecipe, so that if a new option is added the code in this repo would work seamlessly.